### PR TITLE
Added GitHub actions workflow to publish release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.x
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+name: build
+
+permissions:
+  contents: write
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.0.x
+
+      - name: get version
+        id: version
+        uses: notiz-dev/github-action-json-property@release
+        with:
+          path: "plugin.json"
+          prop_path: "Version"
+
+      - run: echo ${{steps.version.outputs.prop}}
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: |
+          dotnet publish -c Release -r win-x64 --no-self-contained Flow.Launcher.Plugin.MediaControl.csproj
+          7z a -tzip "Flow.Launcher.Plugin.MediaControl.zip" "./bin/Release/win-x64/publish/*"
+
+      - name: Publish
+        uses: softprops/action-gh-release@v1
+        with:
+          files: "Flow.Launcher.Plugin.MediaControl.zip"
+          tag_name: "v${{steps.version.outputs.prop}}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
           7z a -tzip "Flow.Launcher.Plugin.MediaControl.zip" "./bin/Release/win-x64/publish/*"
 
       - name: Publish
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: "Flow.Launcher.Plugin.MediaControl.zip"
           tag_name: "v${{steps.version.outputs.prop}}"

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
     "Name": "MediaControl",
     "Description": "A plugin to control media playback",
     "Author": "PederBirk",
-    "Version": "1.0.0",
+    "Version": "1.0.1",
     "Language": "csharp",
     "Website": "https://github.com/PederBirk/Flow.Launcher.Plugin.MediaControl",
     "IcoPath": "icon.png",


### PR DESCRIPTION
As part of adding this plugin to the plugins manifest, so that it can be shown on the flow launcher plugin store, you need to have a published zip. This workflow will produce a release that can then be used as the download link for the plugin manifest. part of the fix to #1 